### PR TITLE
Update XD URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Create layouts on your phone or tablet using natural drawing gestures.
 Design and prototype websites and mobile apps with Adobe XD CC (formerly Project Comet), the first all-in-one tool for UX designers.  
 Adobe XD is an all-in-one UX/UI solution for designing websites, mobile apps, and more.
 
-[http://www.adobe.com/products/experience-design.html](http://www.adobe.com/products/experience-design.html)
+[http://xd.adobe.com/](http://xd.adobe.com/)
 
 ---
 


### PR DESCRIPTION
With the rebranding of Oct 2017 that URL became deprecated. While there is a redirect, it is safest to use xd.adobe.com.